### PR TITLE
fix: 🛠 quotation marks

### DIFF
--- a/matematika/prosti_brojevi/prosti_brojevi.tex
+++ b/matematika/prosti_brojevi/prosti_brojevi.tex
@@ -1,6 +1,6 @@
 \ssection{\reg Prosti brojevi (en. \textit{Prime Numbers})}
 
-\link{Prosti brojevi - GeekforGeeks}{Pogledati i sekciju \"Prime Numbers for Programmers\"}{https://www.geeksforgeeks.org/prime-numbers/}
+\link{Prosti brojevi - GeekforGeeks}{Pogledati i sekciju ``Prime Numbers for Programmers''}{https://www.geeksforgeeks.org/prime-numbers/}
 % Nova strana
 \newpage
 % -----------


### PR DESCRIPTION
Quotation marks do not need to be escaped in LaTeX. The correct way is to use ```` for opening quotes and `''` for closing quotes.

This fixes the failing compilation job.